### PR TITLE
Update ANTLR4 to v4.13.1

### DIFF
--- a/ANTLR.md
+++ b/ANTLR.md
@@ -5,7 +5,7 @@
 
 ## Download ANTLR4 tools
 
-The version currently used can be downloaded [here (antlr-4.13.0-complete.jar)](https://github.com/antlr/website-antlr4/blob/gh-pages/download/antlr-4.13.0-complete.jar).
+The version currently used can be downloaded [here (antlr-4.13.1-complete.jar)](https://github.com/antlr/website-antlr4/blob/gh-pages/download/antlr-4.13.1-complete.jar).
 Or you can always go to [ANTLR4 download page](https://www.antlr.org/download.html).
 
 Download the `.jar` file and place it somewhere a directory.
@@ -16,7 +16,7 @@ Install java and you're ready to work with ANTLR4.
 ## Making ANTLR alias.
 
 ```bash
-alias antlr='java -jar /path/to/downloaded/antlr-4.13.0-complete.jar'
+alias antlr='java -jar /path/to/downloaded/antlr-4.13.1-complete.jar'
 ```
 
 ## Executing ANTLR
@@ -35,6 +35,6 @@ The command `make clean` can be used to remove the generated content of the
 `antlr/parser/grulev3` directory.
 Then, it is possible to generate the parser code with:
 ```bash
-make ANTLR="java -jar /path/to/downloaded/antlr-4.13.0-complete.jar"
+make ANTLR="java -jar /path/to/downloaded/antlr-4.13.1-complete.jar"
 ```
 

--- a/antlr/parser/grulev3/grulev3_base_listener.go
+++ b/antlr/parser/grulev3/grulev3_base_listener.go
@@ -1,4 +1,4 @@
-// Code generated from grulev3.g4 by ANTLR 4.13.0. DO NOT EDIT.
+// Code generated from grulev3.g4 by ANTLR 4.13.1. DO NOT EDIT.
 
 package grulev3 // grulev3
 import "github.com/antlr4-go/antlr/v4"

--- a/antlr/parser/grulev3/grulev3_base_visitor.go
+++ b/antlr/parser/grulev3/grulev3_base_visitor.go
@@ -1,4 +1,4 @@
-// Code generated from grulev3.g4 by ANTLR 4.13.0. DO NOT EDIT.
+// Code generated from grulev3.g4 by ANTLR 4.13.1. DO NOT EDIT.
 
 package grulev3 // grulev3
 import "github.com/antlr4-go/antlr/v4"

--- a/antlr/parser/grulev3/grulev3_lexer.go
+++ b/antlr/parser/grulev3/grulev3_lexer.go
@@ -1,4 +1,4 @@
-// Code generated from grulev3.g4 by ANTLR 4.13.0. DO NOT EDIT.
+// Code generated from grulev3.g4 by ANTLR 4.13.1. DO NOT EDIT.
 
 package grulev3
 

--- a/antlr/parser/grulev3/grulev3_listener.go
+++ b/antlr/parser/grulev3/grulev3_listener.go
@@ -1,4 +1,4 @@
-// Code generated from grulev3.g4 by ANTLR 4.13.0. DO NOT EDIT.
+// Code generated from grulev3.g4 by ANTLR 4.13.1. DO NOT EDIT.
 
 package grulev3 // grulev3
 import "github.com/antlr4-go/antlr/v4"

--- a/antlr/parser/grulev3/grulev3_parser.go
+++ b/antlr/parser/grulev3/grulev3_parser.go
@@ -1,4 +1,4 @@
-// Code generated from grulev3.g4 by ANTLR 4.13.0. DO NOT EDIT.
+// Code generated from grulev3.g4 by ANTLR 4.13.1. DO NOT EDIT.
 
 package grulev3 // grulev3
 import (

--- a/antlr/parser/grulev3/grulev3_visitor.go
+++ b/antlr/parser/grulev3/grulev3_visitor.go
@@ -1,4 +1,4 @@
-// Code generated from grulev3.g4 by ANTLR 4.13.0. DO NOT EDIT.
+// Code generated from grulev3.g4 by ANTLR 4.13.1. DO NOT EDIT.
 
 package grulev3 // grulev3
 import "github.com/antlr4-go/antlr/v4"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DataWiseHQ/grule-rule-engine
 go 1.23.7
 
 require (
-	github.com/antlr4-go/antlr/v4 v4.13.0
+	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/go-git/go-billy/v5 v5.6.0
 	github.com/go-git/go-git/v5 v5.13.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXx
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
-github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
-github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=


### PR DESCRIPTION
Follow up of #3.

Now that Go 1.23 is required, it is possible to update ANTLR to v4.13.1.